### PR TITLE
fix dark mode

### DIFF
--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { ThemeProvider } from '@material-ui/core/styles';
+import React, { useState, useEffect, useMemo } from 'react';
+import { ThemeProvider, createTheme } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 
 import SnackbarController from '../components/snackbar';
@@ -20,13 +20,15 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 
 function MyApp({ Component, pageProps }) {
   const [queryClient] = useState(() => new QueryClient());
-  const [themeConfig, setThemeConfig] = useState(lightTheme);
+  const [isDarkMode, setIsDarkMode] = useState(false);
   const router = useRouter();
 
   const changeTheme = (dark) => {
-    setThemeConfig(dark ? darkTheme : lightTheme);
+    setIsDarkMode(dark ? true : false);
     localStorage.setItem('yearn.finance-dark-mode', dark ? 'dark' : 'light');
   };
+  
+  const Theme = useMemo(() => createTheme(isDarkMode ? darkTheme : lightTheme), [isDarkMode]);
 
   useEffect(function () {
     const localStorageDarkMode = window.localStorage.getItem('yearn.finance-dark-mode');
@@ -57,7 +59,7 @@ function MyApp({ Component, pageProps }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={themeConfig}>
+      <ThemeProvider theme={Theme}>
         <CssBaseline />
         <Component {...pageProps} changeTheme={changeTheme} />
         <SnackbarController />

--- a/frontend/pages/create.js
+++ b/frontend/pages/create.js
@@ -56,13 +56,13 @@ async function create(name, symbol, decimals, limit){
   window.alert(`address of your token is ${token.predictedAddress}`)
 }
 
-function Home() {
+function Home({changeTheme}) {
   const [name, setName] = useState("")
   const [symbol, setSymbol] = useState("")
   const [decimals, setDecimals] = useState("")
   const [limit, setLimit] = useState("")
   return (
-    <Layout searchEnabled={false}>
+    <Layout changeTheme={changeTheme} searchEnabled={false}>
         <div>
         {[
             [symbol, setSymbol, "Symbol", "DAI, WBTC, ..."],

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -3,7 +3,7 @@ import Layout from "../components/layout"
 import { useSearch } from '../stores';
 import Chain from '../components/chain'
 
-function Home() {
+function Home({changeTheme}) {
   const search = useSearch((state) => state.search);
 
   const tokens = [
@@ -16,7 +16,7 @@ function Home() {
   ]
 
   return (
-    <Layout>
+    <Layout changeTheme={changeTheme}>
       {(search === ''
         ? tokens
         : tokens.filter((token) => {

--- a/frontend/theme/dark.js
+++ b/frontend/theme/dark.js
@@ -31,7 +31,7 @@ const theme = createTheme({
       ...coreTheme.overrides.MuiInputBase,
       root: {
         background: "#fff",
-		color: '#000'
+	color: '#000'
       }
     },
     MuiOutlinedInput: {

--- a/frontend/theme/dark.js
+++ b/frontend/theme/dark.js
@@ -30,7 +30,8 @@ const theme = createTheme({
     MuiInputBase: {
       ...coreTheme.overrides.MuiInputBase,
       root: {
-        background: "#fff"
+        background: "#fff",
+		color: '#000'
       }
     },
     MuiOutlinedInput: {


### PR DESCRIPTION
drilled createTheme down to Layout, which was a necessary to fix Header dark mode toggle

other changes are to get dark mode to work better on 'create' page:
1. theme is re-created on toggle to get it to apply properly to components on 'create' page after toggle.
2. .MuiInputBase-root color is changed to black in darkTheme so that textfield text is visible on 'create' page in dark mode. 

did local testing but should be checked by react gods, maybe there is a better fix